### PR TITLE
更新処理に例外ハンドリングを追加。

### DIFF
--- a/DuplicateLiveDataException.java
+++ b/DuplicateLiveDataException.java
@@ -1,8 +1,8 @@
 package com.tsuchiya.live;
 
  // 既存のレコードと同じライブ情報を更新しようとした場合にスローするための例外処理クラス。
-public class SameLiveDataException extends RuntimeException {
-    public SameLiveDataException(String message) {
+public class DuplicateLiveDataException extends RuntimeException {
+    public DuplicateLiveDataException(String message) {
         super(message);
     }
 }

--- a/GlobalExceptionHandler.java
+++ b/GlobalExceptionHandler.java
@@ -7,15 +7,15 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 @ControllerAdvice
 public class GlobalExceptionHandler {
 
-    // LiveNotFoundExceptionとSameLiveDataExceptionを処理するためのハンドラ。
+    // LiveNotFoundExceptionとDuplicateLiveDataExceptionを処理するためのハンドラ。
     @ExceptionHandler(LiveNotFoundException.class)
     public ResponseEntity<LiveResponse> handleLiveNotFoundException(LiveNotFoundException ex) {
         LiveResponse response = new LiveResponse(ex.getMessage());
         return new ResponseEntity<>(response, HttpStatus.NOT_FOUND);
     }
 
-    @ExceptionHandler(SameLiveDataException.class)
-    public ResponseEntity<LiveResponse> handleSameLiveDataException(SameLiveDataException ex) {
+    @ExceptionHandler(DuplicateLiveDataException.class)
+    public ResponseEntity<LiveResponse> handleDuplicateLiveDataException(DuplicateLiveDataException ex) {
         LiveResponse response = new LiveResponse(ex.getMessage());
         return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
     }

--- a/GlobalExceptionHandler.java
+++ b/GlobalExceptionHandler.java
@@ -1,0 +1,23 @@
+package com.tsuchiya.live;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    // LiveNotFoundExceptionとSameLiveDataExceptionを処理するためのハンドラ。
+    @ExceptionHandler(LiveNotFoundException.class)
+    public ResponseEntity<LiveResponse> handleLiveNotFoundException(LiveNotFoundException ex) {
+        LiveResponse response = new LiveResponse(ex.getMessage());
+        return new ResponseEntity<>(response, HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler(SameLiveDataException.class)
+    public ResponseEntity<LiveResponse> handleSameLiveDataException(SameLiveDataException ex) {
+        LiveResponse response = new LiveResponse(ex.getMessage());
+        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+    }
+}
+

--- a/LiveApplication.java
+++ b/LiveApplication.java
@@ -11,3 +11,4 @@ public class LiveApplication {
     }
 
 }
+

--- a/LiveController.java
+++ b/LiveController.java
@@ -26,17 +26,9 @@ public class LiveController {
 
     @PatchMapping("/{id}")
     public ResponseEntity<LiveResponse> update(@PathVariable("id") Integer id, @RequestBody LiveRequest liveRequest) {
-        try {
             liveService.update(id, liveRequest.getSchedule(), liveRequest.getName(), liveRequest.getLocation());
             LiveResponse body = new LiveResponse("live updated"); // リクエストが成功した場合、200で返す。
             return ResponseEntity.ok(body);
-        } catch (SameLiveDataException ex) {
-            LiveResponse body = new LiveResponse(ex.getMessage());
-            return ResponseEntity.status(400).body(body); // 重複の場合、400を返す。
-        } catch (LiveNotFoundException ex) {
-            LiveResponse body = new LiveResponse(ex.getMessage());
-            return ResponseEntity.status(404).body(body); // 対象のライブが見つからない場合、404を返す。
-        }
     }
 }
 

--- a/LiveController.java
+++ b/LiveController.java
@@ -26,10 +26,17 @@ public class LiveController {
 
     @PatchMapping("/{id}")
     public ResponseEntity<LiveResponse> update(@PathVariable("id") Integer id, @RequestBody LiveRequest liveRequest) {
-        liveService.update(id, liveRequest.getSchedule(), liveRequest.getName(), liveRequest.getLocation());
-        LiveResponse body = new LiveResponse("live updated");
-        return ResponseEntity.ok(body);
+        try {
+            liveService.update(id, liveRequest.getSchedule(), liveRequest.getName(), liveRequest.getLocation());
+            LiveResponse body = new LiveResponse("live updated"); // リクエストが成功した場合、200で返す。
+            return ResponseEntity.ok(body);
+        } catch (SameLiveDataException ex) {
+            LiveResponse body = new LiveResponse(ex.getMessage());
+            return ResponseEntity.status(400).body(body); // 重複の場合、400を返す。
+        } catch (LiveNotFoundException ex) {
+            LiveResponse body = new LiveResponse(ex.getMessage());
+            return ResponseEntity.status(404).body(body); // 対象のライブが見つからない場合、404を返す。
+        }
     }
-
 }
 

--- a/LiveMapper.java
+++ b/LiveMapper.java
@@ -16,7 +16,10 @@ public interface LiveMapper {
     @Select("SELECT * FROM live WHERE id = #{id}")
     Optional<Live> findById(Integer id);
 
+    @Select("SELECT COUNT(*) > 0 FROM live WHERE schedule = #{schedule} AND name = #{name} AND location = #{location} AND id != #{id}")
+    boolean isDuplicate(String schedule, String name, String location, Integer id); // liveのレコードの重複チェックを行うためのMyBatisのSQLクエリ
+
     @Update("UPDATE live SET schedule = #{schedule}, name = #{name}, location = #{location} WHERE id = #{id}")
-    void update(Live live);
+    void update(Live live); // liveのレコードを更新するためのMyBatisのSQLクエリ
 }
 

--- a/LiveNotFoundException.java
+++ b/LiveNotFoundException.java
@@ -1,0 +1,9 @@
+package com.tsuchiya.live;
+
+ // 指定されたIDに対応するライブ情報が見つからない場合にスローするための例外処理クラス。
+public class LiveNotFoundException extends RuntimeException {
+    public LiveNotFoundException(String message){
+        super(message);
+    }
+}
+

--- a/LiveService.java
+++ b/LiveService.java
@@ -28,7 +28,7 @@ public class LiveService {
 
         // 既存のレコードと同じ場合は更新しない。
         if (liveMapper.isDuplicate(schedule, name, location, id)) {
-            throw new SameLiveDataException("Cannot update with the same data");
+            throw new DuplicateLiveDataException("Cannot update with the same data");
         }
 
         // ライブ情報が見つかった場合に更新処理を行う。

--- a/LiveService.java
+++ b/LiveService.java
@@ -24,12 +24,18 @@ public class LiveService {
 
     public void update(Integer id, String schedule, String name, String location) {
         Optional<Live> liveOptional = liveMapper.findById(id);
-        liveOptional.ifPresent(live -> {
-            live.setSchedule(schedule);
-            live.setName(name);
-            live.setLocation(location);
-            liveMapper.update(live);
-        });
+        Live live = liveOptional.orElseThrow(() -> new LiveNotFoundException("That id live is not registered"));
+
+        // 既存のレコードと同じ場合は更新しない。
+        if (liveMapper.isDuplicate(schedule, name, location, id)) {
+            throw new SameLiveDataException("Cannot update with the same data");
+        }
+
+        // ライブ情報が見つかった場合に更新処理を行う。
+        live.setSchedule(schedule);
+        live.setName(name);
+        live.setLocation(location);
+        liveMapper.update(live);
     }
 }
 

--- a/SameLiveDataException.java
+++ b/SameLiveDataException.java
@@ -1,0 +1,9 @@
+package com.tsuchiya.live;
+
+ // 既存のレコードと同じライブ情報を更新しようとした場合にスローするための例外処理クラス。
+public class SameLiveDataException extends RuntimeException {
+    public SameLiveDataException(String message) {
+        super(message);
+    }
+}
+


### PR DESCRIPTION
# 第10回課題
## 概要
- 最終課題のliveプロジェクトの更新処理に
①指定されたIDに対応するライブ情報が見つからない場合にスローするための例外処理(LiveNotFoundException)
② 既存のレコードと同じライブ情報を更新しようとした場合にスローするための例外処理 (DuplicateLiveDataException)
~~(SameLiveDataException)~~ 
以上の2つの例外ハンドリングを追加しましたので、レビューをお願いします。

## liveテーブルレコード
![スクリーンショット (107)](https://github.com/kttsu/learning_task_10/assets/150462533/e2868311-f18f-4b74-8697-f815911973bb)

## 動作確認
①指定されたIDに対応するライブ情報が見つからない場合、id6は存在しないので、404と "message": "That id live is not registered"を返す。
![スクリーンショット (105)](https://github.com/kttsu/learning_task_10/assets/150462533/b7c3075b-923d-40da-971b-52b226b02681)

②id1に登録されている同じライブの情報をid2に更新しようとした場合、400と"message": "Cannot update with the same data"を返す。
![スクリーンショット (106)](https://github.com/kttsu/learning_task_10/assets/150462533/2cc309fe-ba0c-48dc-bb6c-6ff07ece409d)

