### PR TITLE
Serviceの単体テスト(findById)と例外処理の実装。

### DIFF
--- a/LiveServiceTest.java
+++ b/LiveServiceTest.java
@@ -25,7 +25,7 @@ class LiveServiceTest {
 
 
     @Test
-    public void testFindAll_Service() {
+    public void 全てのliveを取得するテスト() {
         Live live1 = new Live(1, "2024-6-6 19:00:00", "PRAYING MANTIS", "梅田Club Quattro");
         Live live2 = new Live(2, "2024-9-24 19:00:00", "IRON MAIDEN", "大阪城ホール");
         Live live3 = new Live(3, "2024-10-19 18:00:00", "JOURNEY", "Asueアリーナ大阪");
@@ -41,7 +41,7 @@ class LiveServiceTest {
     }
 
     @Test
-    public void testFindById_Service() {
+    public void idでliveを取得するテスト() {
         int existingId = 1;
         Live expectedLive = new Live(existingId, "2024-06-06 19:00:00", "PRAYING MANTIS", "梅田Club Quattro");
         when(liveMapper.findById(existingId)).thenReturn(Optional.of(expectedLive));
@@ -52,7 +52,7 @@ class LiveServiceTest {
     }
 
     @Test
-    public void testFindById_Exception_Service() {
+    public void 存在しないidで例外が投げられることのテスト() {
         int nonExistingId = 6;
 
         when(liveMapper.findById(nonExistingId)).thenReturn(Optional.empty());

--- a/LiveServiceTest.java
+++ b/LiveServiceTest.java
@@ -1,17 +1,17 @@
 package com.tsuchiya.live;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -38,6 +38,26 @@ class LiveServiceTest {
 
         assertEquals(expected.size(), actual.size());
         assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testFindById_Service() {
+        int existingId = 1;
+        Live expectedLive = new Live(existingId, "2024-06-06 19:00:00", "PRAYING MANTIS", "梅田Club Quattro");
+        when(liveMapper.findById(existingId)).thenReturn(Optional.of(expectedLive));
+
+        Live actualLive = liveService.findById(existingId);
+
+        assertEquals(expectedLive, actualLive);
+    }
+
+    @Test
+    public void testFindById_Exception_Service() {
+        int nonExistingId = 6;
+
+        when(liveMapper.findById(nonExistingId)).thenReturn(Optional.empty());
+
+        assertThrows(LiveNotFoundException.class, () -> liveService.findById(nonExistingId));
     }
 }
 


### PR DESCRIPTION
# 第10回課題
## 概要
- 最終課題のliveプロジェクト、Serviceの単体テストで、
①指定したIdを取得するテスト(findById)の実装。
②存在しないIdを指定した場合の例外処理の実装。
以上2点を実装しました。レビューをお願いします。

## テスト結果
①指定したIdを取得した時のテスト結果(idでliveを取得するテスト) ~~(testFindById_Service)~~
![スクリーンショット (132)](https://github.com/kttsu/learning_task_10/assets/150462533/11e7e594-4102-43c3-bfb4-d156ba188b57)

②存在しないIdを指定した場合の例外処理のテスト結果(存在しないidで例外が投げられることのテスト) 
 ~~(testFindById_Exception_Service)~~
![スクリーンショット (136)](https://github.com/kttsu/learning_task_10/assets/150462533/87191dd0-ef4e-44f6-a055-e4956ba7f86a)