### PR TITLE
DBテストと結合テストの実装(削除処理と例外処理)。

### DIFF
--- a/LiveMapperTest.java
+++ b/LiveMapperTest.java
@@ -71,5 +71,15 @@ public class LiveMapperTest {
         boolean isDuplicate = liveMapper.isDuplicate("2024-05-09 19:00:00", "Yngwie J.Malmsteen", "zepp namba", 2);
         assertThat(isDuplicate).isTrue();
     }
+
+    @Test
+    @DataSet(value = "datasets/live.yml")
+    @Transactional
+    void 指定したidでliveの情報を削除できること() {
+        Integer id = 1;
+        liveMapper.delete(id);
+
+        Optional<Live> liveOptional = liveMapper.findById(id);
+    }
 }
 

--- a/LiveMapperTest.java
+++ b/LiveMapperTest.java
@@ -2,6 +2,7 @@ package com.tsuchiya.live;
 
 import com.github.database.rider.core.api.dataset.DataSet;
 import com.github.database.rider.spring.api.DBRider;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -80,6 +81,7 @@ public class LiveMapperTest {
         liveMapper.delete(id);
 
         Optional<Live> liveOptional = liveMapper.findById(id);
+        Assertions.assertTrue(liveOptional.isEmpty());
     }
 }
 

--- a/LiveRestApiIntegrationTest.java
+++ b/LiveRestApiIntegrationTest.java
@@ -194,7 +194,7 @@ public class LiveRestApiIntegrationTest {
     @Test
     @DataSet(value = "datasets/live.yml")
     @Transactional
-    void 存在しないliveのidを削除したとき404を返すこと() throws Exception {
+    void 存在しないliveのidを削除したとき404とメッセージを返すこと() throws Exception {
         mockMvc.perform(MockMvcRequestBuilders.delete("/live/6"))
                 .andExpect(MockMvcResultMatchers.status().isNotFound())
                 .andExpect(MockMvcResultMatchers.content().json("""

--- a/LiveRestApiIntegrationTest.java
+++ b/LiveRestApiIntegrationTest.java
@@ -176,8 +176,9 @@ public class LiveRestApiIntegrationTest {
 
     @Test
     @DataSet(value = "datasets/live.yml")
+    @ExpectedDataSet(value = "datasets/expectedLiveDataAfterDelete.yml", ignoreCols = "id")
     @Transactional
-    void 存在するliveのidを指定して削除できること() throws Exception {
+    void 指定したidのliveがDBから削除されメッセージが返ること() throws Exception {
         mockMvc.perform(MockMvcRequestBuilders.delete("/live/1"))
                 .andExpect(MockMvcResultMatchers.status().isOk())
                 .andExpect(MockMvcResultMatchers.content().json("""

--- a/LiveRestApiIntegrationTest.java
+++ b/LiveRestApiIntegrationTest.java
@@ -12,6 +12,7 @@ import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.transaction.annotation.Transactional;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -134,6 +135,7 @@ public class LiveRestApiIntegrationTest {
                 .andExpect(jsonPath("$.location").value("NEW LOCATION"));
     }
 
+
     @Test
     @DataSet(value = "datasets/live.yml")
     @Transactional
@@ -153,8 +155,8 @@ public class LiveRestApiIntegrationTest {
         // レスポンスの内容を文字列として取得し,エラーメッセージが含まれていることを確認
         String jsonResponse = response.getContentAsString();
         assertTrue(jsonResponse.contains("Cannot update with the same data"));
-
     }
+
 
     @Test
     @DataSet(value = "datasets/live.yml")
@@ -170,6 +172,35 @@ public class LiveRestApiIntegrationTest {
                                 }
                                 """))
                 .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DataSet(value = "datasets/live.yml")
+    @Transactional
+    void 存在するliveのidを指定して削除できること() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.delete("/live/1"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.content().json("""
+                        {
+                          "message": "live deleted"
+                        }
+                        """));
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/live/1"))
+                .andExpect(MockMvcResultMatchers.status().isNotFound());
+    }
+
+    @Test
+    @DataSet(value = "datasets/live.yml")
+    @Transactional
+    void 存在しないliveのidを削除したとき404を返すこと() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.delete("/live/6"))
+                .andExpect(MockMvcResultMatchers.status().isNotFound())
+                .andExpect(MockMvcResultMatchers.content().json("""
+                        {
+                          "message": "That live id cannot be deleted"
+                        }
+                        """));
     }
 }
 


### PR DESCRIPTION
# 第10回課題
## 概要
- 最終課題のliveプロジェクト、DBテストと結合テストの実装(削除処理と例外処理)をしました。
レビューをお願いします。

##  DBテスト結果
①指定したidでliveの情報を削除できること
![スクリーンショット (214)](https://github.com/kttsu/learning_task_10/assets/150462533/56e7b7a1-6bd3-4cba-ab59-f9ff7ad8c4e8)

## 結合テスト結果
①指定したidのliveがDBから削除されメッセージが返ること
![スクリーンショット (215)](https://github.com/kttsu/learning_task_10/assets/150462533/be9236c2-ce14-4103-bbfc-afa3e169c66e)


② 存在しないliveのidを削除したとき404とメッセージを返すこと
![スクリーンショット (216)](https://github.com/kttsu/learning_task_10/assets/150462533/eaf16862-3134-4d5c-a9b6-7160d786f131)

#### ①の結合テストの補足説明
※「存在するliveのidを指定して削除できること」から「指定したidのliveがDBから削除されメッセージが返ること」に変更(3d6e06b691039edf0569ded6b8ac90794a1f694f)した際、[expectedLiveDataAfterDeleteを追加。](https://github.com/kttsu/learning_task_10/commit/a01e0ae2889c6b594427ab445a43bfe2a76437ea) しました。